### PR TITLE
Prevent ansi color from being spewed out

### DIFF
--- a/lib/Sourceable/Plugin/Sourcery.pm6
+++ b/lib/Sourceable/Plugin/Sourcery.pm6
@@ -2,6 +2,8 @@ unit class Sourceable::Plugin::Sourcery;
 use MONKEY-SEE-NO-EVAL;
 use CoreHackers::Sourcery;
 
+%*ENV<RAKUDO_ERROR_COLOR> = 0;
+
 has $.executable-dir is required;
 has $.core-hackers   is required;
 


### PR DESCRIPTION
A better solution would be to make it use Whateverable, but
for now this is going to work ;)